### PR TITLE
Set multiline flag on regex to fix specs that come with details in bullet points

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -1,5 +1,5 @@
 // Pattern to match for requirement checkboxes
-const MATCH_REQ = /^\s*(\d+): (.+)$/
+const MATCH_REQ = /^\s*(\d+): (.+)$/m
 
 // Element selectors
 const select = {


### PR DESCRIPTION
<img width="457" alt="screen shot 2017-12-11 at 6 15 05 pm" src="https://user-images.githubusercontent.com/315395/33864026-85f2875c-de9f-11e7-9a2f-87b267536ee5.png">

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
* http://scriptular.com/ did not catch it!